### PR TITLE
Remove models' dependency on Rocket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "aardwolf"
 version = "0.1.0"
 authors = ["Eric Chadbourne <sillystring@protonmail.com>", "Elijah Mark Anderson <kd0bpv@gmail.com>", "Paul Woolcock <paul@woolcock.us>", "Asonix <asonix.dev@gmail.com>"]
 description = "Powering connected social communities with free software."
+autobins = false
 
 [workspace]
 members = [
@@ -57,6 +58,7 @@ simple-logging = {version = "2.0.1", optional = true}
 [dependencies.aardwolf-models]
 version = "0.1"
 path = "aardwolf-models"
+features = ["rocket"]
 
 [dependencies.chrono]
 version = "0.4"

--- a/aardwolf-models/Cargo.toml
+++ b/aardwolf-models/Cargo.toml
@@ -12,11 +12,14 @@ failure = "0.1"
 log = "0.4"
 mime = "0.3"
 rand = "0.5"
-rocket = "0.3.14"
+rocket = { version = "0.3.14", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 url = "1.7"
+
+[features]
+default = []
 
 [dependencies.diesel]
 version = "1.2"

--- a/aardwolf-models/src/lib.rs
+++ b/aardwolf-models/src/lib.rs
@@ -11,6 +11,7 @@ extern crate failure;
 extern crate log;
 extern crate mime;
 extern crate rand;
+#[cfg(feature = "rocket")]
 extern crate rocket;
 extern crate serde;
 #[macro_use]

--- a/aardwolf-models/src/sql_types/follow_policy.rs
+++ b/aardwolf-models/src/sql_types/follow_policy.rs
@@ -74,6 +74,7 @@ impl StdError for FollowPolicyParseError {
     }
 }
 
+#[cfg(feature = "rocket")]
 mod rocket {
     use std::str::Utf8Error;
 

--- a/aardwolf-models/src/sql_types/post_visibility.rs
+++ b/aardwolf-models/src/sql_types/post_visibility.rs
@@ -77,6 +77,7 @@ impl StdError for VisibilityParseError {
     }
 }
 
+#[cfg(feature = "rocket")]
 mod rocket {
     use std::str::Utf8Error;
 

--- a/aardwolf-models/src/sql_types/url.rs
+++ b/aardwolf-models/src/sql_types/url.rs
@@ -43,6 +43,7 @@ impl FromStr for Url {
     }
 }
 
+#[cfg(feature = "rocket")]
 mod rocket {
     use std::str::Utf8Error;
 

--- a/aardwolf-models/src/user/email/token.rs
+++ b/aardwolf-models/src/user/email/token.rs
@@ -128,6 +128,7 @@ impl fmt::Display for EmailVerificationToken {
     }
 }
 
+#[cfg(feature = "rocket")]
 mod rocket {
     use std::str::Utf8Error;
 

--- a/aardwolf-models/src/user/local_auth/password.rs
+++ b/aardwolf-models/src/user/local_auth/password.rs
@@ -124,6 +124,7 @@ impl ValidationError {
 #[derive(Deserialize)]
 pub struct PlaintextPassword(String);
 
+#[cfg(feature = "rocket")]
 mod rocket {
     use std::str::Utf8Error;
 


### PR DESCRIPTION
This change puts rocket behind a feature flag for aardwolf-models

useful for https://github.com/Aardwolf-Social/aardwolf/issues/151