### PR TITLE
Add ActivityPub IDs to Posts and Actors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -81,6 +82,7 @@ dependencies = [
  "rocket_contrib 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_i18n 0.3.0 (git+https://github.com/Aardwolf-Social/rocket_i18n.git?branch=asonix/rocket-stable)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/aardwolf-actix/Cargo.toml
+++ b/aardwolf-actix/Cargo.toml
@@ -16,6 +16,7 @@ r2d2-diesel = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+uuid = "0.6"
 
 [dependencies.aardwolf-models]
 version = "0.1"

--- a/aardwolf-actix/src/routes/personas.rs
+++ b/aardwolf-actix/src/routes/personas.rs
@@ -122,7 +122,7 @@ pub(crate) fn create(
     let res = perform!(state, PersonaCreateError, [
         (form = ValidatePersonaCreationForm(form)),
         (creater = CheckCreatePersonaPermission(user.0)),
-        (_ = CreatePersona(creater, form)),
+        (_ = CreatePersona(creater, form, state.generator.clone())),
     ]);
 
     Box::new(

--- a/aardwolf-models/migrations/2019-01-18-212737_add_activitypub_ids/down.sql
+++ b/aardwolf-models/migrations/2019-01-18-212737_add_activitypub_ids/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE base_posts
+    DROP COLUMN activitypub_id;
+
+ALTER TABLE base_actors
+    DROP COLUMN activitypub_id;

--- a/aardwolf-models/migrations/2019-01-18-212737_add_activitypub_ids/up.sql
+++ b/aardwolf-models/migrations/2019-01-18-212737_add_activitypub_ids/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+ALTER TABLE base_actors
+    ADD COLUMN activitypub_id VARCHAR(300) UNIQUE NOT NULL;
+
+ALTER TABLE base_posts
+    ADD COLUMN activitypub_id VARCHAR(300) UNIQUE NOT NULL;

--- a/aardwolf-models/src/base_actor/mod.rs
+++ b/aardwolf-models/src/base_actor/mod.rs
@@ -74,6 +74,7 @@ pub struct BaseActor {
     private_key_der: Vec<u8>,
     public_key_der: Vec<u8>,
     local_uuid: Option<Uuid>,
+    activitypub_id: String,
 }
 
 impl BaseActor {
@@ -158,6 +159,7 @@ pub struct NewBaseActor {
     private_key_der: Vec<u8>,
     public_key_der: Vec<u8>,
     local_uuid: Option<Uuid>,
+    activitypub_id: String,
 }
 
 impl NewBaseActor {
@@ -175,20 +177,20 @@ impl NewBaseActor {
         follow_policy: FollowPolicy,
         private_key_der: Vec<u8>,
         public_key_der: Vec<u8>,
+        generate_urls: impl GenerateUrls,
     ) -> Self {
         let uuid = Uuid::new_v4();
-        // use throw-away unique URL since we can infer local URLs.
-        let local_url: Url = format!("https://example.com/{}", uuid).parse().unwrap();
 
         NewBaseActor {
             display_name,
-            profile_url: local_url.clone(),
-            inbox_url: local_url.clone(),
-            outbox_url: local_url,
+            profile_url: generate_urls.profile_url(&uuid),
+            inbox_url: generate_urls.inbox_url(&uuid),
+            outbox_url: generate_urls.outbox_url(&uuid),
             local_user: Some(local_user.id()),
             follow_policy,
             private_key_der,
             public_key_der,
+            activitypub_id: generate_urls.activitypub_id(&uuid),
             local_uuid: Some(uuid),
         }
     }
@@ -201,6 +203,7 @@ impl NewBaseActor {
         follow_policy: FollowPolicy,
         private_key_der: Vec<u8>,
         public_key_der: Vec<u8>,
+        activitypub_id: String,
     ) -> Self {
         NewBaseActor {
             display_name,
@@ -212,8 +215,16 @@ impl NewBaseActor {
             private_key_der,
             public_key_der,
             local_uuid: None,
+            activitypub_id,
         }
     }
+}
+
+pub trait GenerateUrls {
+    fn activitypub_id(&self, uuid: &Uuid) -> String;
+    fn profile_url(&self, uuid: &Uuid) -> Url;
+    fn inbox_url(&self, uuid: &Uuid) -> Url;
+    fn outbox_url(&self, uuid: &Uuid) -> Url;
 }
 
 #[cfg(test)]

--- a/aardwolf-models/src/base_post/mod.rs
+++ b/aardwolf-models/src/base_post/mod.rs
@@ -27,6 +27,7 @@ pub struct BasePost {
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
     local_uuid: Option<Uuid>,
+    activitypub_id: String,
 }
 
 impl BasePost {
@@ -77,6 +78,7 @@ pub struct NewBasePost {
     icon: Option<i32>,
     visibility: PostVisibility,
     local_uuid: Option<Uuid>,
+    activitypub_id: String,
 }
 
 impl NewBasePost {
@@ -94,14 +96,18 @@ impl NewBasePost {
         posted_by: &BaseActor,
         icon: Option<&Image>,
         visibility: PostVisibility,
+        generate_id: impl Fn(&Uuid) -> String,
     ) -> Self {
+        let uuid = Uuid::new_v4();
+
         NewBasePost {
             name,
             media_type: media_type.into(),
             posted_by: posted_by.id(),
             icon: icon.map(|i| i.id()),
             visibility,
-            local_uuid: Some(Uuid::new_v4()),
+            activitypub_id: generate_id(&uuid),
+            local_uuid: Some(uuid),
         }
     }
 
@@ -111,6 +117,7 @@ impl NewBasePost {
         posted_by: &BaseActor,
         icon: Option<&Image>,
         visibility: PostVisibility,
+        activitypub_id: String,
     ) -> Self {
         NewBasePost {
             name,
@@ -119,6 +126,7 @@ impl NewBasePost {
             icon: icon.map(|i| i.id()),
             visibility,
             local_uuid: None,
+            activitypub_id,
         }
     }
 }

--- a/aardwolf-models/src/schema.rs
+++ b/aardwolf-models/src/schema.rs
@@ -13,6 +13,7 @@ table! {
         private_key_der -> Bytea,
         public_key_der -> Bytea,
         local_uuid -> Nullable<Uuid>,
+        activitypub_id -> Varchar,
     }
 }
 
@@ -27,6 +28,7 @@ table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         local_uuid -> Nullable<Uuid>,
+        activitypub_id -> Varchar,
     }
 }
 

--- a/aardwolf-models/src/test_helper.rs
+++ b/aardwolf-models/src/test_helper.rs
@@ -10,6 +10,7 @@ use openssl::rsa::Rsa;
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use serde_json;
 use url::Url as OrigUrl;
+use uuid::Uuid;
 
 use crate::{
     base_actor::{
@@ -20,7 +21,7 @@ use crate::{
             Group, NewGroup,
         },
         persona::{NewPersona, Persona},
-        BaseActor, NewBaseActor,
+        BaseActor, GenerateUrls, NewBaseActor,
     },
     base_post::{
         direct_post::{DirectPost, NewDirectPost},
@@ -126,6 +127,7 @@ where
         FollowPolicy::AutoAccept,
         pr,
         pu,
+        gen_string()?,
     )
     .insert(conn)?;
 
@@ -141,6 +143,26 @@ pub fn gen_keypair() -> Result<(Vec<u8>, Vec<u8>), GenericError> {
     ))
 }
 
+pub struct UrlGenerator;
+
+impl GenerateUrls for UrlGenerator {
+    fn activitypub_id(&self, uuid: &Uuid) -> String {
+        uuid.to_string()
+    }
+
+    fn profile_url(&self, uuid: &Uuid) -> Url {
+        format!("https://example.com/{}", uuid).parse().unwrap()
+    }
+
+    fn inbox_url(&self, uuid: &Uuid) -> Url {
+        format!("https://example.com/{}", uuid).parse().unwrap()
+    }
+
+    fn outbox_url(&self, uuid: &Uuid) -> Url {
+        format!("https://example.com/{}", uuid).parse().unwrap()
+    }
+}
+
 pub fn user_with_base_actor<F>(
     conn: &PgConnection,
     user: &AuthenticatedUser,
@@ -151,8 +173,15 @@ where
 {
     let (pr, pu) = gen_keypair()?;
 
-    let base_actor =
-        NewBaseActor::local(gen_string()?, user, FollowPolicy::AutoAccept, pr, pu).insert(conn)?;
+    let base_actor = NewBaseActor::local(
+        gen_string()?,
+        user,
+        FollowPolicy::AutoAccept,
+        pr,
+        pu,
+        UrlGenerator,
+    )
+    .insert(conn)?;
 
     f(base_actor)
 }
@@ -236,8 +265,15 @@ pub fn with_base_post<F>(
 where
     F: FnOnce(BasePost) -> Result<(), GenericError>,
 {
-    let base_post =
-        NewBasePost::new(None, TEXT_PLAIN, posted_by, None, PostVisibility::Public).insert(conn)?;
+    let base_post = NewBasePost::local(
+        None,
+        TEXT_PLAIN,
+        posted_by,
+        None,
+        PostVisibility::Public,
+        |uuid| format!("{}", uuid),
+    )
+    .insert(conn)?;
 
     f(base_post)
 }

--- a/aardwolf-rocket/Cargo.toml
+++ b/aardwolf-rocket/Cargo.toml
@@ -17,6 +17,7 @@ r2d2 = "0.8"
 r2d2-diesel = "1.0"
 serde = "1.0.21"
 log = "0.4.1"
+uuid = "0.6"
 
 [dependencies.aardwolf-models]
 version = "0.1"

--- a/aardwolf-rocket/src/lib.rs
+++ b/aardwolf-rocket/src/lib.rs
@@ -132,6 +132,11 @@ fn app(config: &config::Config, db_url: &str) -> Result<Rocket, Box<dyn Error>> 
         .extra("database_url", db_url)
         .unwrap();
 
+    let url_generator = UrlGenerator {
+        domain: config.get_str("Instance.domain")?,
+        https: config.get_bool("Instance.https")?,
+    };
+
     let mut routes = routes![routes::app::home, routes::app::home_redirect,];
 
     #[cfg(debug_assertions)]
@@ -177,10 +182,7 @@ fn app(config: &config::Config, db_url: &str) -> Result<Rocket, Box<dyn Error>> 
     // we need an instance of the app to access the config values in Rocket.toml,
     // so we pass it to the db_pool function, get the pool, and _then_ return the instance
     let pool = db_pool(&r)?;
-    Ok(r.manage(pool).manage(UrlGenerator {
-        domain: "example.com".to_owned(),
-        https: true,
-    }))
+    Ok(r.manage(pool).manage(url_generator))
 }
 
 pub fn run(config: &config::Config, db_url: &str) -> Result<(), Box<dyn Error>> {

--- a/aardwolf-rocket/src/lib.rs
+++ b/aardwolf-rocket/src/lib.rs
@@ -3,7 +3,9 @@
 
 #[macro_use]
 extern crate rocket;
+use std::{error::Error, ops::Deref};
 
+use aardwolf_models::{base_actor::GenerateUrls, sql_types::Url};
 use aardwolf_templates::Renderable;
 use diesel::pg::PgConnection;
 use r2d2_diesel::ConnectionManager;
@@ -12,7 +14,7 @@ use rocket::{
     request::{self, FromRequest},
     Outcome, Request, Response, Rocket, State,
 };
-use std::{error::Error, ops::Deref};
+use uuid::Uuid;
 
 #[macro_use]
 pub mod action;
@@ -23,6 +25,56 @@ pub mod types;
 mod response_or_redirect;
 
 pub use crate::response_or_redirect::ResponseOrRedirect;
+
+#[derive(Clone)]
+pub struct UrlGenerator {
+    domain: String,
+    https: bool,
+}
+
+impl GenerateUrls for UrlGenerator {
+    fn activitypub_id(&self, uuid: &Uuid) -> String {
+        format!(
+            "{}://{}/users/{}",
+            if self.https { "https" } else { "http" },
+            self.domain,
+            uuid
+        )
+    }
+
+    fn profile_url(&self, uuid: &Uuid) -> Url {
+        format!(
+            "{}://{}/users/{}/profile",
+            if self.https { "https" } else { "http" },
+            self.domain,
+            uuid
+        )
+        .parse()
+        .unwrap()
+    }
+
+    fn inbox_url(&self, uuid: &Uuid) -> Url {
+        format!(
+            "{}://{}/users/{}/inbox",
+            if self.https { "https" } else { "http" },
+            self.domain,
+            uuid
+        )
+        .parse()
+        .unwrap()
+    }
+
+    fn outbox_url(&self, uuid: &Uuid) -> Url {
+        format!(
+            "{}://{}/users/{}/outbox",
+            if self.https { "https" } else { "http" },
+            self.domain,
+            uuid
+        )
+        .parse()
+        .unwrap()
+    }
+}
 
 pub fn render_template<R>(r: &R) -> Response<'static>
 where
@@ -125,7 +177,10 @@ fn app(config: &config::Config, db_url: &str) -> Result<Rocket, Box<dyn Error>> 
     // we need an instance of the app to access the config values in Rocket.toml,
     // so we pass it to the db_pool function, get the pool, and _then_ return the instance
     let pool = db_pool(&r)?;
-    Ok(r.manage(pool))
+    Ok(r.manage(pool).manage(UrlGenerator {
+        domain: "example.com".to_owned(),
+        https: true,
+    }))
 }
 
 pub fn run(config: &config::Config, db_url: &str) -> Result<(), Box<dyn Error>> {

--- a/aardwolf-rocket/src/routes/personas.rs
+++ b/aardwolf-rocket/src/routes/personas.rs
@@ -21,11 +21,11 @@ use rocket::{
     http::{Cookie, Cookies, Status},
     request::Form,
     response::Redirect,
-    Response,
+    Response, State,
 };
 use rocket_i18n::I18n;
 
-use crate::{render_template, types::user::SignedInUser, DbConn, ResponseOrRedirect};
+use crate::{render_template, types::user::SignedInUser, DbConn, ResponseOrRedirect, UrlGenerator};
 
 #[get("/create")]
 pub fn new(_user: SignedInUser, i18n: I18n) -> Response<'static> {
@@ -87,6 +87,7 @@ impl From<CheckCreatePersonaPermissionFail> for PersonaCreateError {
 
 #[post("/create", data = "<form>")]
 pub fn create(
+    generator: State<UrlGenerator>,
     user: SignedInUser,
     form: Form<PersonaCreationForm>,
     i18n: I18n,
@@ -99,7 +100,7 @@ pub fn create(
     let res = perform!(&db, PersonaCreateError, [
         (form = ValidatePersonaCreationForm(form)),
         (creator = CheckCreatePersonaPermission(user.0)),
-        (_ = CreatePersona(creator, form)),
+        (_ = CreatePersona(creator, form, generator.inner().clone())),
     ]);
 
     let res = match res {


### PR DESCRIPTION
It doesn't make sense to have ActivityPub Objects without IDs.

This also introduces the GenerateUrls trait, which can be used to create URLs from a UUID without the models needing to know what the URL scheme is