### PR TITLE
Hide clippy warnings for ructe, big function

### DIFF
--- a/aardwolf-templates/src/first_login.rs
+++ b/aardwolf-templates/src/first_login.rs
@@ -16,6 +16,7 @@ pub struct FirstLogin<'a> {
 }
 
 impl<'a> FirstLogin<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         catalog: &'a Catalog,
         csrf: &'a str,

--- a/aardwolf-templates/src/lib.rs
+++ b/aardwolf-templates/src/lib.rs
@@ -1,7 +1,5 @@
-extern crate aardwolf_models;
-extern crate aardwolf_types;
-extern crate gettext;
-extern crate rocket_i18n;
+#![allow(clippy::inline_fn_without_body)]
+#![allow(clippy::into_iter_on_ref)]
 include!("../compiled_templates/templates.rs");
 
 mod first_login;


### PR DESCRIPTION
Make clippy happy in aardwolf-templates (for now). We can actually make the too_many_arguments part a bit cleaner probably