### PR TITLE
Make private key optional

### DIFF
--- a/aardwolf-models/migrations/2019-01-18-211319_make_private_key_nullable/down.sql
+++ b/aardwolf-models/migrations/2019-01-18-211319_make_private_key_nullable/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE base_actors ALTER COLUMN private_key_der SET NOT NULL;

--- a/aardwolf-models/migrations/2019-01-18-211319_make_private_key_nullable/up.sql
+++ b/aardwolf-models/migrations/2019-01-18-211319_make_private_key_nullable/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE base_actors ALTER COLUMN private_key_der DROP NOT NULL;

--- a/aardwolf-models/src/base_actor/mod.rs
+++ b/aardwolf-models/src/base_actor/mod.rs
@@ -25,7 +25,7 @@ pub struct ModifiedBaseActor {
     inbox_url: Url,
     outbox_url: Url,
     follow_policy: FollowPolicy,
-    private_key_der: Vec<u8>,
+    private_key_der: Option<Vec<u8>>,
     public_key_der: Vec<u8>,
 }
 
@@ -71,7 +71,7 @@ pub struct BaseActor {
     follow_policy: FollowPolicy, // max_length: 8
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
-    private_key_der: Vec<u8>,
+    private_key_der: Option<Vec<u8>>,
     public_key_der: Vec<u8>,
     local_uuid: Option<Uuid>,
 }
@@ -155,7 +155,7 @@ pub struct NewBaseActor {
     outbox_url: Url,
     local_user: Option<i32>,
     follow_policy: FollowPolicy,
-    private_key_der: Vec<u8>,
+    private_key_der: Option<Vec<u8>>,
     public_key_der: Vec<u8>,
     local_uuid: Option<Uuid>,
 }
@@ -187,7 +187,7 @@ impl NewBaseActor {
             outbox_url: local_url,
             local_user: Some(local_user.id()),
             follow_policy,
-            private_key_der,
+            private_key_der: Some(private_key_der),
             public_key_der,
             local_uuid: Some(uuid),
         }
@@ -199,7 +199,6 @@ impl NewBaseActor {
         inbox_url: Url,
         outbox_url: Url,
         follow_policy: FollowPolicy,
-        private_key_der: Vec<u8>,
         public_key_der: Vec<u8>,
     ) -> Self {
         NewBaseActor {
@@ -209,7 +208,7 @@ impl NewBaseActor {
             outbox_url,
             local_user: None,
             follow_policy,
-            private_key_der,
+            private_key_der: None,
             public_key_der,
             local_uuid: None,
         }

--- a/aardwolf-models/src/schema.rs
+++ b/aardwolf-models/src/schema.rs
@@ -10,7 +10,7 @@ table! {
         follow_policy -> Varchar,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
-        private_key_der -> Bytea,
+        private_key_der -> Nullable<Bytea>,
         public_key_der -> Bytea,
         local_uuid -> Nullable<Uuid>,
     }

--- a/aardwolf-models/src/test_helper.rs
+++ b/aardwolf-models/src/test_helper.rs
@@ -116,7 +116,7 @@ pub fn with_base_actor<F>(conn: &PgConnection, f: F) -> Result<(), GenericError>
 where
     F: FnOnce(BaseActor) -> Result<(), GenericError>,
 {
-    let (pr, pu) = gen_keypair()?;
+    let (_pr, pu) = gen_keypair()?;
 
     let base_actor = NewBaseActor::new(
         gen_string()?,
@@ -124,7 +124,6 @@ where
         gen_url()?,
         gen_url()?,
         FollowPolicy::AutoAccept,
-        pr,
         pu,
     )
     .insert(conn)?;


### PR DESCRIPTION
Private Keys will only be stored for local actors, so they shouldn't be mandatory