### PR TITLE
Update documentation formatting

### DIFF
--- a/doc/SETUP-NGINX.md
+++ b/doc/SETUP-NGINX.md
@@ -1,4 +1,4 @@
-## NGINX Configuration
+### NGINX Configuration
 Because Rocket isn't really designed to serve static files (i.e. CSS, images, etc.) it is necessary to use a web server application.  Banjo's favorite is NGINX because its FAST, and does not require reams of paper to print configurations ;) (most of the time).<br />
 
 `../config/nginx/aardwolf-nginx.conf` -- This is the "server" block, which is basically a clone of the Mastodon config (Banjo is extreeeemely lazy...) but without all the "cruft"
@@ -10,20 +10,21 @@ Sample NGINX configurations are available in the config directory:
 
 
 ### Setting up NGINX - The fast way (FUTURE)
-Debian: 
+Debian:
 
 ```
-$ sudo apt-get install nginx
-$ sudo mkdir /etc/nginx/includes
-$ sudo cp [path_to_aardwolf_repo]/config/nginx/aardwolf-nginx.conf /etc/nginx/sites-available/
-$ sudo cp [path_to_aardwolf_repo]/config/nginx/includes/* /etc/nginx/includes/
-$ sudo /etc/nginx/sites-available/aardwolf-nginx.conf /etc/nginx/sites-enabled/aardwolf-nginx.conf
-$ sudo nginx -s reload
+  $ sudo apt-get install nginx
+  $ sudo mkdir /etc/nginx/includes
+  $ sudo cp [path_to_aardwolf_repo]/config/nginx/aardwolf-nginx.conf /etc/nginx/sites-available/
+  $ sudo cp [path_to_aardwolf_repo]/config/nginx/includes/* /etc/nginx/includes/
+  $ sudo /etc/nginx/sites-available/aardwolf-nginx.conf /etc/nginx/sites-enabled/aardwolf-nginx.conf
+  $ sudo nginx -s reload
 ```
 Then browse to `http://localhost` :D
 
 
 ### The TROUBLESHOOTING way -- (Because locations are still mostly broken v.v)
+```
 $ sudo apt-get install nginx
 $ sudo mkdir /etc/nginx/includes
 $ sudo cp [path_to_aardwolf_repo]/config/nginx/troubleshooting.conf /etc/nginx/sites-available/
@@ -31,4 +32,5 @@ $ sudo cp [path_to_aardwolf_repo]/config/nginx/includes/* /etc/nginx/includes/
 $ sudo /etc/nginx/sites-available/troubleshooting.conf /etc/nginx/sites-enabled/troubleshooting.conf
 $ sudo nginx -s reload
 ```
+
 Then browse to `http://localhost:8000`, and try to figure out what borked D:

--- a/doc/SETUP-POSTGRES.md
+++ b/doc/SETUP-POSTGRES.md
@@ -1,7 +1,7 @@
 To setup and start the database server, first install PostGRE SQL as described here:
 [INSTALL-POSTGRES.md](INSTALL-POSTGRES.md)
 
-## Configure postgres user and database cluster directory ##
+### Configure postgres user and database cluster directory ##
 
 Installation should create a system user and a group called `postgres`.
 Set its password via `passwd postgres`.
@@ -12,32 +12,32 @@ The postgres user must have ownership for that directory.
 
     $ sudo chown postgres:postgres /var/lib/postgres/data
 
-## Setup database and start database server for Aardwolf ##
+### Setup database and start database server for Aardwolf ##
 
-**The following commands need to be done as the postgres user.** 
+**The following commands need to be done as the postgres user.**
 
 Enter a shell as the postgres user
 
     $ su postgres
 
-Initialize the database cluster 
+Initialize the database cluster
 
     $ initdb -D /var/lib/postgres/data
 
 Start the database server
 
     $ pg_ctl start -D /var/lib/postgres/data -l serverlog
-    
+
 > If this says permission denied for a directory where it wants to store a lockfile, create that directory and assign permissions as in the case above.
 
 Create the database for Aardwolf
-    
+
     $ psql -c "CREATE DATABASE aardwolf;"
 
 Create the DB user
 
     $ psql -c "CREATE USER aardwolf WITH PASSWORD 'p4ssw0rd'"
-    
+
 *** DO NOT USE THESE VALUES IN PRODUCTION :D ***
 
 **You can now `exit` the postgres user shell.**

--- a/doc/SETUP-WEBPACK.md
+++ b/doc/SETUP-WEBPACK.md
@@ -1,4 +1,4 @@
-# INTRODUCTION
+### INTRODUCTION
 
 Rather than including full packages for application/web styling (Bulma.io, ForkAwesome, etc) we are using WebPack.
 The alternative would be to simply include CDN links (ex: https://bulma.io/path/to/bulma-min.css), however there may
@@ -6,50 +6,40 @@ be folks that would prefer to have local copies of everything.
 
 This document will describe how to use WebPack
 
-## Requirements
-Install Node 
-(Node documentation)[https://github.com/nodesource/distributions/blob/master/README.md]
+### Requirements
+#### Install Node
+[Node documentation](https://github.com/nodesource/distributions/blob/master/README.md)
 
-Install npm
-(npm documentation)[https://www.npmjs.com/package/npm]
+#### Install npm
+[npm documentation](https://www.npmjs.com/package/npm)
 
 Update npm (Just to be safe)
-`npm install npm@latest -g`
 
-## Setup WebPack for Aardwolf (Work in Progress)
+    $ npm install npm@latest -g
+
+### Setup WebPack for Aardwolf (Work in Progress)
 
 Go into the aardwolf directory
-`cd /path/to/aardwolf`
 
- Initialize the setup script (it is okay to accept the default values)
- `npm init`
+    $ cd /path/to/aardwolf
 
- Install the dependencies
- - webpack, and webpack-cli should be installed first the rest are in alphabetical order
-```
-npm install webpack --save-dev
-npm install webpack-cli --save-dev
-npm install bulma --save-dev
-npm install clean-webpack-plugin --save-dev
-npm install css-loader --save-dev
-npm install extract-text-webpack-plugin@next --save-dev
-npm install mini-css-extract-plugin --save-dev
-npm install node-sass --save-dev
-npm install sass-loader --save-dev
-npm install style-loader --save-dev
-```
+Install the dependencies
+
+    $ npm install --dev
+
 Regarding warnings:
 On Linux you may see a couple of warnings such as the ones below.  Don't fret because these dependencies are for Mac OS.
+
 ```
 npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.7 (node_modules/fsevents):
 npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.7: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
 ```
 
 Build the packages
-`npm run build`
+
+    $ npm run build
 
 Thats it!
 
 Source URL:
 https://bulma.io/documentation/customize/with-webpack/
-

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
+  mode: 'development',
   entry: './web/javascript/app.js',
   output: {
     filename: 'app.js',


### PR DESCRIPTION
To make the documentation more consistent, I reformatted everything to follow how `INSTALL-RUST.md` was formatted.

I also tweaked the webpack install guide to use the existing [`package.json`](https://github.com/Aardwolf-Social/aardwolf/blob/master/package.json) rather then creating a new one. 