### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Ignore tests
+tests
+
+# Ignore git
+.git
+.gitignore
+
+# Ignore prebuilt
+node_modules
+target
+
+# Ignore docs
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM rust:1.39 as app-builder
+WORKDIR /usr/src/aardwolf
+COPY . .
+RUN cp config/example.toml aardwolf.toml \
+    && apt-get update \
+    && apt-get install -y libpq-dev gettext \
+    && cargo build --release --bin aardwolf-server --bin setup
+
+
+FROM rust:1.39 as desiel-builder
+RUN cargo install diesel_cli --no-default-features --features "postgres"
+
+
+FROM node:13.3 as asset-builder
+WORKDIR /usr/src/aardwolf
+COPY . .
+RUN npm install \
+  && npm run build
+
+
+FROM debian:buster-slim
+WORKDIR /etc/aardwolf
+RUN mkdir -p assets \
+  && apt-get update \
+  && apt-get install -y libpq-dev openssl \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/
+COPY config/example.toml aardwolf.toml
+COPY docker-entrypoint.sh /
+COPY aardwolf-models/migrations /usr/src/aardwolf/migrations
+COPY web assets/web
+COPY aardwolf-templates/templates assets/templates
+COPY --from=asset-builder /usr/src/aardwolf/dist assets/dist
+COPY --from=app-builder /usr/src/aardwolf/target/release/aardwolf-server /usr/local/bin/
+COPY --from=app-builder /usr/src/aardwolf/target/release/setup /usr/local/bin/aardwolf-setup
+COPY --from=desiel-builder /usr/local/cargo/bin/diesel /usr/local/bin/
+EXPOSE 8080
+ENTRYPOINT /docker-entrypoint.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,15 +1,37 @@
 # Installation instructions
 
-Theoretically, Aardwolf should run anywhere that Rust and PostgreSQL
+Theoretically, Aardwolf should run anywhere that Rust and PostgreSQL (or Docker)
 run. At the moment it has only been tested on linux, OSX, and Windows 10.
 
 > NOTE: These instructions may help in installing a production version, but are
 intended for developers to be able to build and test their changes. If in doubt,
 seek out documentation from your distribution package or from the [`doc`](doc) folder.
 
-## Installing Requirements
+## Docker Deployment
 
-### Installing PostgreSQL
+Deploying with Docker is the easiest way to get Aardwolf running.
+Assuming that you already have docker and docker-compose installed,
+(if not then you can them [here](https://docs.docker.com/) and
+[here](https://docs.docker.com/compose/install/))
+all you need to do is clone the repo:
+
+    $ git clone https://github.com/aardwolf-social/aardwolf
+    $ cd aardwolf
+
+Configure the included `docker-compose.yml` to your liking.
+(see the environment variable table in [Configuring the server](#Configuring-the-server) for
+more information)
+
+Then deploy:
+
+    $ docker-compose up
+
+
+## Manual Deployment
+
+### Installing Requirements
+
+#### Installing PostgreSQL
 In order to run the Aardwolf backend, you will need to have access to a
 [PostgreSQL](https://www.postgresql.org/) database. There are a few options for doing this, but for
 this guide we’re going to assume you are running the database on your
@@ -20,7 +42,7 @@ Full details can be found here:
 - [INSTALL-POSTGRES.md](/doc/INSTALL-POSTGRES.md)
 - [SETUP-POSTGRES.md](/doc/SETUP-POSTGRES.md)
 
-### Installing Rust Environment
+#### Installing Rust Environment
 
 Next, you’ll need to have the [Rust](https://rust-lang.org/) toolchain
 installed. The best way to do this is to install
@@ -30,7 +52,7 @@ Full details can be found here:
 
 - [INSTALL-RUST.md](/doc/INSTALL-RUST.md)
 
-## Getting the source
+### Getting the source
 
 To get the source, use `git` to checkout this repo:
 
@@ -40,7 +62,7 @@ Then, `cd` into the source directory
 
     $ cd aardwolf
 
-## Setting the Rust toolchain version
+### Setting the Rust toolchain version
 
 We could continue to use the `+nightly` feature whenever we run a
 `cargo` command, but why do the extra typing? Let’s set up a `rustup`
@@ -68,7 +90,7 @@ To verify that the version in the project directory is what we just set, in the 
 
     $ rustup show
 
-## Configuring the server
+### Configuring the server
 
 Currently, Aardwolf expects `aardwolf.toml` to be in the root of the project
 directory. To get started, copy
@@ -87,7 +109,7 @@ You may also override this configuration file using the following environment va
 | AARDWOLF_DATABASE_PASSWORD | `p4ssw0rd`       | The password for the database. |
 
 
-## Setting up the database
+### Setting up the database
 
 Change to the aardwolf-server directory
 
@@ -98,7 +120,7 @@ following command to set up the aardwolf database:
 
     $ cargo run --bin setup
 
-## Running the server
+### Running the server
 
 Finally, we get to actually run the darn thing!
 To run the server with Actix.rs as the backend:

--- a/aardwolf-actix/src/lib.rs
+++ b/aardwolf-actix/src/lib.rs
@@ -108,7 +108,6 @@ fn db_pool(database_url: &str) -> Result<Pool<ConnectionManager<PgConnection>>, 
     Ok(pool)
 }
 
-#[cfg(debug_assertions)]
 mod assets {
     use std::error::Error;
 
@@ -172,7 +171,6 @@ pub fn run(config: &Config, database_url: &str) -> Result<(), Box<dyn Error>> {
         https: config.get_bool("Instance.https")?,
     };
 
-    #[cfg(debug_assertions)]
     let assets = assets::Assets::from_config(&config)?;
 
     HttpServer::new(move || {

--- a/config/example.toml
+++ b/config/example.toml
@@ -59,7 +59,7 @@ stylesheets = "web/stylesheets"
 [Templates]
 # Templates - the directories where UI templates are stored
 
-dir = "./templates/**/*"
+dir = "./aardwolf-templates/templates/**/*"
 
 [Log]
 # Log - This section describes how logging should be handled in the application

--- a/config/example.toml
+++ b/config/example.toml
@@ -47,6 +47,9 @@ password = "p4ssw0rd"
 #
 # Database.database - Which database on the server holds Aardwolf's information.
 database = "aardwolf"
+#
+# Database.migrations - Path to where migrations can be found
+migrations = "aardwolf-models/migrations"
 
 # Assets - This is where static files are stored for running in development mode
 [Assets]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     ports:
       - 8080:8080
     environment:
+      AARDWOLF_INSTANCE_DOMAIN: localhost
       AARDWOLF_DATABASE_HOST: db
       AARDWOLF_DATABASE_USERNAME: aardwolf
       AARDWOLF_DATABASE_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_USER: aardwolf
+      POSTGRES_PASSWORD: password
+
+  app:
+    build: .
+    depends_on:
+      - db
+    ports:
+      - 8080:8080
+    environment:
+      AARDWOLF_DATABASE_HOST: db
+      AARDWOLF_DATABASE_USERNAME: aardwolf
+      AARDWOLF_DATABASE_PASSWORD: password

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Create sane default config for a docker deployment
+export AARDWOLF_CONFIG=/etc/aardwolf/aardwolf.toml
+
+export AARDWOLF_WEB_HOST=0.0.0.0
+export AARDWOLF_LOG_FILE=_CONSOLE_
+export AARDWOLF_DATABASE_MIGRATIONS=/etc/aardwolf/migrations
+
+# NOTE: Would be nice if all the asset stuff was in one directory and a single config value.
+export AARDWOLF_ASSETS_WEB=/etc/aardwolf/assets/dist
+export AARDWOLF_ASSETS_THEMES=/etc/aardwolf/assets/web/themes
+export AARDWOLF_ASSETS_EMOJI=/etc/aardwolf/assets/web/emoji
+export AARDWOLF_ASSETS_IMAGES=/etc/aardwolf/assets/web/images
+export AARDWOLF_ASSETS_STYLESHEETS=/etc/aardwolf/assets/web/stylesheets
+export AARDWOLF_TEMPLATES_DIR=/etc/aardwolf/assets/templates/**/*
+
+if [[ -z $AARDWOLF_DATABASE_HOST ]]; then
+  echo "ERROR: AARDWOLF_DATABASE_HOST is not set"
+  return 1
+fi
+
+# Run migrations
+aardwolf-setup
+
+# Run server
+aardwolf-server "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,6 +20,9 @@ if [[ -z $AARDWOLF_DATABASE_HOST ]]; then
   return 1
 fi
 
+# Hack to wait for postgres to start
+sleep 10
+
 # Run migrations
 aardwolf-setup
 

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -43,7 +43,11 @@ fn main() {
     let output = Command::new("diesel")
         .arg("setup")
         .arg("--migration-dir")
-        .arg("aardwolf-models/migrations")
+        .arg(
+            config
+                .get_str("Database.migrations")
+                .unwrap_or("aarwolf_models/migrations".to_string()),
+        )
         .env("DATABASE_URL", &db_url)
         .output();
     check_out(&output);


### PR DESCRIPTION
Create docker images for Aardwolf.

Todo before merging:
- [x] Dockerfile
- [x] docker-compose.yml
- [x] docker-entrypoint.sh
- [x] Documentation

Some things to consider (in order of usefulness):
- [ ] Aardwolf logging to STDOUT
- [ ] [Automatic Travis docker image builds](https://docs.travis-ci.com/user/docker/)
   - [ ] amd64
  - [ ] arm64
- [ ] Deployment to Docker Hub
- [ ] [Image scanning](https://github.com/quay/clair)