### PR TITLE
Update travis postgresql version to 13.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - postgresql
 
 addons:
-  postgresql: "9.6"
+  postgresql: "13.2"
 
 before_script:
   - echo "BEFORE SCRIPT"


### PR DESCRIPTION
Just what the commit says.
Bump Travis postgresql from 9.6 to 13.2