### PR TITLE
Travis Fix - drop postgres version info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: rust
 services:
   - postgresql
 
-addons:
-  postgresql: "13.2"
-
 before_script:
   - echo "BEFORE SCRIPT"
   - psql -c 'CREATE DATABASE aardwolf_testing;' -U postgres


### PR DESCRIPTION
Removed postgres version info, which seems to be what is throwing travis off.  We're not currently using any postgres features that specifically use the newest version, so it should be acceptable to use an older postgres for the test build.