### PR TITLE
Nicholas/fix travis and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: rust
 services:
   - postgresql
 
-addons:
-  postgresql: "13.2"
-
 before_script:
   - echo "BEFORE SCRIPT"
   - psql -c 'CREATE DATABASE aardwolf_testing;' -U postgres

--- a/aardwolf-models/Cargo.toml
+++ b/aardwolf-models/Cargo.toml
@@ -17,17 +17,15 @@ rand = "0.7"
 serde = "1.0"
 serde_json = "1.0"
 url = "2.1"
+dotenv="0.14"
+
 [dependencies.uuid]
 version = "0.6"
 features = ["v4"]
 
 [features]
 default = []
-test = ["dotenv"]
-
-[dependencies.dotenv]
-version = "0.14"
-optional = true
+test = []
 
 [dependencies.diesel]
 version = "1.4"

--- a/aardwolf-models/src/test_helper.rs
+++ b/aardwolf-models/src/test_helper.rs
@@ -65,9 +65,7 @@ pub fn transmute_email_token(token: &EmailToken) -> Result<EmailVerificationToke
 }
 
 pub fn gen_string() -> Result<String, Error> {
-    let mut rng = OsRng::new()?;
-
-    Ok(rng.sample_iter(&Alphanumeric).take(10).collect())
+    Ok(OsRng.sample_iter(&Alphanumeric).take(10).collect())
 }
 
 pub fn gen_url() -> Result<Url, Error> {
@@ -79,11 +77,11 @@ pub fn gen_url() -> Result<Url, Error> {
 }
 
 pub fn gen_bool() -> Result<bool, Error> {
-    Ok(OsRng::new()?.gen())
+    Ok(OsRng.gen())
 }
 
 pub fn gen_datetime() -> Result<DateTime<Utc>, Error> {
-    let hours = OsRng::new()?.gen_range(0, 10000);
+    let hours = OsRng.gen_range(0, 10000);
 
     Ok(Utc::now()
         .checked_add_signed(OldDuration::hours(hours))

--- a/aardwolf-templates/Cargo.toml
+++ b/aardwolf-templates/Cargo.toml
@@ -26,3 +26,6 @@ path = "../aardwolf-types"
 [dependencies.aardwolf-models]
 version = "0.1"
 path = "../aardwolf-models"
+
+[dev-dependencies]
+ructe = "0.13"


### PR DESCRIPTION
Removed postgres version info, which seems to be what is throwing travis off. We're not currently using any postgres features that specifically use the newest version, so it should be acceptable to use an older postgres for the test build.

After the rng fixes (my apologies for not catching that I broke that), all that was left to build and pass the (single) test was to add some entries to the dev depencies