### PR TITLE
Create TOML versions of CLI and SETUP YAMLs

### DIFF
--- a/src/bin/cli.toml
+++ b/src/bin/cli.toml
@@ -1,0 +1,24 @@
+name = "aardwolf-server"
+version = "unknown"
+author = "Please see README for credits"
+about = "Powering connected social communities with open software."
+
+[[args]] # Define table array "args"
+[args.config] # Sub-table of "args"
+short = "c"
+long = "config"
+value_name = "CFG_FILE"
+help = "Sets a custom config file"
+takes_value = true
+
+[args.log] # Also a sub-table of "args"
+short = "l"
+long = "log"
+value_name = "LOG_FILE"
+help = "Sets logging destination"
+takes_value = true
+
+[args.verbose] # Also a sub-table of "args"
+short = "v"
+multiple = true
+help = "Sets the level of verbosity"

--- a/src/bin/setup.toml
+++ b/src/bin/setup.toml
@@ -1,0 +1,17 @@
+name = "aardwolf-setup"
+version = "unknown"
+author = "Please see README for credits"
+about = "development setup utility"
+
+[[args]] # Define table array "args"
+[args.config] # Sub-table of "args"
+short = "c"
+long = "config"
+value_name = "CFG_FILE"
+help = "Sets a custom config file"
+takes_value = true
+
+[args.verbose] # Also a sub-table of "args"
+short = "v"
+multiple = true
+help = "Sets the level of verbosity"


### PR DESCRIPTION
Created TOML-formatted versions of the two YAML-formatted files in /src/bin.
The reasoning for this is the fact that `yaml-rust` crate hasn't been updated in 4 years, and Clap hasn't supported YAML parsing since version 3.0.0 (current is 4.3.8).

TOML seems to be more widely supported, and in fact is required by Rust for the `rust-toolchain` file.