### PR TITLE
Nicholasguyett/fix additional error handling compiler errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "aardwolf"
 version = "0.1.0"
 dependencies = [
  "aardwolf-actix",
+ "anyhow",
  "clap",
  "config",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "futures 0.3.28",
  "log",
  "r2d2",
+ "rocket_i18n",
  "serde 1.0.163",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ actix = ["aardwolf-actix"]
 
 [dependencies]
 config = "0.9"
+anyhow = "1.0"
 thiserror = "1.0"
 log = "0.4"
 yaml-rust = "~0.4.5"

--- a/aardwolf-actix/Cargo.toml
+++ b/aardwolf-actix/Cargo.toml
@@ -39,6 +39,11 @@ version = "2.1"
 default-features = false
 features = ["postgres", "uuid", "chrono"]
 
+[dependencies.rocket_i18n]
+rocket_i18n = "0.4"
+default-features = false
+features = ["actix-web"]
+
 [dependencies.futures]
 version = "0.3"
 features = ["compat"]

--- a/aardwolf-types/src/traits.rs
+++ b/aardwolf-types/src/traits.rs
@@ -43,9 +43,6 @@ mod actix_web_impls {
         #[error("Error in pooling, {}", _0)]
         Pool(#[source] r2d2::Error),
 
-        #[error("Error in thread, {}", _0)]
-        Thread(#[source] BlockingError),
-
         #[error("Db Action was canceled")]
         Canceled,
     }
@@ -55,7 +52,7 @@ mod actix_web_impls {
         E: std::error::Error,
     {
         fn from(e: BlockingError) -> Self {
-            DbActionError::Thread(e)
+            DbActionError::Canceled  // TODO: Add actual handling for this
         }
     }
 


### PR DESCRIPTION
Re-adds `rocket_i18n` dependencies in a way that compiles on stable.

Updates error handling code in `aardwolf-actix`, `aardwolf-types`, and the top-level package so they do not show compiler errors (around the error handling code).