### PR TITLE
Fix actix/routes/auth header -> append_header

### DIFF
--- a/aardwolf-actix/src/routes/auth.rs
+++ b/aardwolf-actix/src/routes/auth.rs
@@ -134,7 +134,7 @@ pub(crate) async fn sign_out((session, _user): (Session, SignedInUser)) -> HttpR
     session.remove("user_id");
 
     HttpResponse::SeeOther()
-        .header(LOCATION, "/auth/sign_in")
+        .append_header((LOCATION, "/auth/sign_in"))
         .finish()
 }
 


### PR DESCRIPTION
Fixes remaining deprecated used of `header`