### PR TITLE
Banjofox/fix src lib.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ members = [
 [features]
 default = ["simple-logging", "actix"]
 actix = ["aardwolf-actix"]
+log-syslog = []
+log-systemd = []
 
 [dependencies]
 anyhow = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::io::ErrorKind;
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -6,8 +5,9 @@ use clap_verbosity_flag::Verbosity;
 use config::{Config, Environment, File, FileFormat};
 use log::LevelFilter;
 use std::path::PathBuf;
+use url::Url;
+use thiserror::Error;
 
-/// Command line arguments struct
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
@@ -21,91 +21,93 @@ pub struct Args {
     verbose: Verbosity,
 }
 
-/// Configures the application using the parsed command line arguments
-pub fn configure(parsed_args: Args) -> Result<(Config, String)> {
-    let config_path = match parsed_args.config {
-        Some(path) => path,
-        None => {
-            eprintln!("No config path provided");
-            std::process::exit(1);
-        }
-    };
+#[derive(Debug, Error)]
+enum ConfigError {
+    #[error("No config path provided")]
+    NoConfigPath,
+    #[error("No log path provided")]
+    NoLogPath,
+    #[error("Invalid log path provided")]
+    InvalidLogPath,
+    #[error("Failed to get database connection string")]
+    DbConnStringError,
+    #[error("Failed to build configuration")]
+    ConfigBuildError,
+}
+
+pub fn configure(parsed_args: Args) -> Result<(Config, String), ConfigError> {
+    let config_path = parsed_args.config.ok_or(ConfigError::NoConfigPath)?;
+    let log_path = parsed_args.log.ok_or(ConfigError::NoLogPath)?;
 
     let config = Config::builder()
-        .add_default(File::with_name("default_config.toml"))?
-        .add_default(Environment::with_prefix("MY_APP"))?
-        .add_default(Environment::with_prefix("MY_APP").separator("__"))?
-        .add_default(Environment::with_prefix("MY_APP").separator("__").ignore_empty(true))?
-        .add_source(File::from(config_path))?
+        .add_source(File::with_name("default_config.toml", FileFormat::Toml))
+        .set_default(Environment::with_prefix("AARDWOLF").separator("__").ignore_empty(true))
+        .add_source(File::from(&config_path))
         .with(|builder| {
-            let config_file = config_path.to_str().unwrap_or_default();
-            set_config_file_override(builder, &config_file)?;
-            builder.add_source(File::new(&config_file, FileFormat::Toml))?;
-            builder.merge(create_override_config(&config_file)?).context(ErrorKind::ConfigImmutable)?;
-            let env_prefix = env!("CARGO_PKG_NAME").to_ascii_uppercase().replace_char('-', '_');
+            let config_file = config_path.to_str().ok_or(ConfigError::NoConfigPath)?;
+            builder.add_source(File::new(&config_file, FileFormat::Toml)).map_err(|_| ConfigError::ConfigBuildError)?;
+            builder.merge(create_override_config(&config_file)).map_err(|_| ConfigError::ConfigBuildError)?;
+            let env_prefix = env!("CARGO_PKG_NAME").to_ascii_uppercase().replace('-', '_');
             let env_vars = Environment::with_prefix(env_prefix).separator("_").ignore_empty(true);
             builder.add_source(env_vars);
-            let log_path = parsed_args.log.ok_or_else(|| anyhow::anyhow!("No log path provided"))?;
-            let log_file = log_path.to_str().unwrap_or_default();
-            builder.set_override("Log.file", &log_file).context(ErrorKind::ConfigImmutable)?;
+            let log_file = log_path.to_str().ok_or(ConfigError::InvalidLogPath)?;
+            builder.set_override("Log.file", &log_file).map_err(|_| ConfigError::ConfigBuildError)?;
             Ok(())
         })?
-        .build()?;
+        .build().map_err(|_| ConfigError::ConfigBuildError)?;
 
     let db_url = db_conn_string(&config)?;
     Ok((config, db_url))
 }
 
-/// Creates an override configuration with the provided config file
-fn create_override_config(config_file: &str) -> Result<Config> {
+fn db_conn_string(config: &Config) -> Result<String> {
+    let db_type = config.get_string("Database.type")?;
+    let username = config.get_string("Database.username")?;
+    let password = config.get_string("Database.password")?;
+    let host = config.get_string("Database.host")?;
+    let port = config.get_string("Database.port")?;
+    let database = config.get_string("Database.database")?;
+
+    let db_url = Url::parse(&format!("{}://{}:{}@{}:{}/{}", db_type, username, password, host, port, database))?;
+    Ok(db_url.as_str().to_owned())
+}
+
+fn create_override_config(config_file: &str) -> Result<(), ConfigError> {
     let mut overrides = Config::default();
     overrides.set("cfg_file", config_file)?;
-    Ok(overrides)
+    Ok(())
 }
 
-/// Generates a database connection string based on the provided config
-pub fn db_conn_string(config: &Config) -> Result<String> {
-    const SUPPORTED_SCHEMES: [&str; 4] = ["postgres", "postgresql", "mysql", "sqlite"];
-
-    let db_config = DatabaseConfig {
-        db_type: config.get_string("Database.type")?,
-        username: config.get_string("Database.username")?,
-        password: config.get_string("Database.password")?,
-        host: config.get_string("Database.host")?,
-        port: config.get_string("Database.port")?,
-        database: config.get_string("Database.database")?,
-    };
-
-    if !SUPPORTED_SCHEMES.contains(&db_config.db_type.as_str()) {
-        Err(ErrorKind::UnsupportedDbScheme)?;
+pub fn begin_log(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    let log_file = config.get_string("Log.file")?;
+    if log_file != "_CONSOLE_" {
+        simple_logging::log_to_file(&log_file, level)?;
     }
-
-    Ok(format!("{}://{}:{}@{}:{}/{}", db_config.db_type, db_config.username, db_config.password, db_config.host, db_config.port, db_config.database))
-}
-
-struct DatabaseConfig {
-    db_type: String,
-    username: String,
-    password: String,
-    host: String,
-    port: String,
-    database: String,
+    Ok(())
 }
 
 #[cfg(feature = "simple-logging")]
-/// Begins logging based on the provided config and log level
-pub fn begin_log(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
-    let log_file = config.get_string("Log.file")?;
-    if log_file != "_CONSOLE_" {
-        simple_logging::log_to_file(&log_file, level)?;
-    }
-    Ok(())
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
 }
 
 #[cfg(feature = "syslog")]
-/// Begins logging based on the provided config and log level
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}
+
+#[cfg(feature = "systemd")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}   let host = config.get_string("Database.host")?;
+    let port = config.get_string("Database.port")?;
+    let database = config.get_string("Database.database")?;
+
+    let db_url = Url::parse(&format!("{}://{}:{}@{}:{}/{}", db_type, username, password, host, port, database))?;
+    Ok(db_url.as_str().to_owned())
+}
+
 pub fn begin_log(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
-    // TODO: Implement log-syslog:begin_log()
     let log_file = config.get_string("Log.file")?;
     if log_file != "_CONSOLE_" {
         simple_logging::log_to_file(&log_file, level)?;
@@ -113,13 +115,17 @@ pub fn begin_log(config: &config::Config, level: LevelFilter) -> Result<(), Box<
     Ok(())
 }
 
+#[cfg(feature = "simple-logging")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}
+
+#[cfg(feature = "syslog")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}
+
 #[cfg(feature = "systemd")]
-/// Begins logging based on the provided config and log level
-pub fn begin_log(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
-    // TODO: Implement use-systemd:begin_log()
-    let log_file = config.get_string("Log.file")?;
-    if log_file != "_CONSOLE_" {
-        simple_logging::log_to_file(&log_file, level)?;
-    }
-    Ok(())
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,20 @@
 use std::env;
+use std::io::ErrorKind;
 use anyhow::{Context, Result};
 use clap::Parser;
 use clap_verbosity_flag::Verbosity;
-use config::{Config, ConfigError, Environment};
+use config::{Config, Environment, File, FileFormat};
+use log::LevelFilter;
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     #[arg(short = 'c', long, help = "Sets a custom config file")]
-    config: Option<std::path::PathBuf>,
+    config: Option<PathBuf>,
 
     #[arg(short = 'l', long, help = "Sets logging destination")]
-    log: Option<std::path::PathBuf>,
+    log: Option<PathBuf>,
 
     #[command(flatten)]
     verbose: Verbosity,
@@ -19,56 +22,50 @@ pub struct Args {
 
 pub fn configure(parsed_args: Args) -> Result<Config> {
     // Set defaults
-    let mut config = Config::default();
-    config
-        .set_default::<&str>("cfg_file", concat!(env!("CARGO_PKG_NAME"), ".toml"))
-        .context(ErrorKind::ConfigImmutable)?;
-    config
-        .set_default::<&str>("Log.file", "_CONSOLE_")
-        .context(ErrorKind::ConfigImmutable)?;
-    config
-        .set_default::<&str>("Web.address", "127.0.0.1")
-        .context(ErrorKind::ConfigImmutable)?;
-    config
-        .set_default("Web.port", 7878)
-        .context(ErrorKind::ConfigImmutable)?;
+    let mut builder = Config::builder()
+        .set_default("cfg_file", concat!(env!("CARGO_PKG_NAME"), ".toml"))?
+        .set_default("Log.file", "_CONSOLE_")?
+        .set_default("Web.address", "127.0.0.1")?
+        .set_default("Web.port", 7878)?
+        .set_default("Database.type", "postgres")?;
 
     // Determine config file
-    if let Ok(config_file) = env::var("AARDWOLF_CONFIG") {
-        config
-            .set("cfg_file", config_file)
-            .context(ErrorKind::ConfigImmutable)?;
-    }
+    let config_path = parsed_args.config.ok_or_else(|| anyhow::anyhow!("No config path provided"))?;
+    let config_file = config_path.to_str().ok_or_else(|| anyhow::anyhow!("Failed to convert config path to string"))?;
 
-    if let Some(config_path) = parsed_args.config {
-        config
-            .set("cfg_file", config_path.to_str())
-            .context(ErrorKind::ConfigImmutable)?;
-    }
-
-    // Merge config file and apply overrides
-    let config_file_string = config
-        .get_string("cfg_file")
-        .context(ErrorKind::ConfigMissingKeys)?;
-    let config_file = config::File::with_name(&config_file_string);
-    config.merge(config_file).context(ErrorKind::ConfigImmutable)?;
+    builder = set_config_file_override(builder, config_file)?;
+    builder = builder.add_source(File::new(config_file, FileFormat::Toml));
+    builder = builder
+        .merge(create_override_config(config_file)?)
+        .context(ErrorKind::ConfigImmutable)?;
 
     // Apply environment variable overrides
-    let env_vars = Environment::with_prefix("AARDWOLF")
+    let env_prefix = env!("CARGO_PKG_NAME").to_ascii_uppercase().replace_char('-', '_');
+    let env_vars = Environment::with_prefix(env_prefix)
         .separator("_")
         .ignore_empty(true);
-    config.merge(env_vars).context(ErrorKind::ConfigImmutable)?;
+    builder = builder.add_source(env_vars);
 
-    // Remove the need for a .env file to avoid defining env vars twice.
-    env::set_var("DATABASE_URL", db_conn_string(&config)?);
+    let log_path = parsed_args.log.ok_or_else(|| anyhow::anyhow!("No log path provided"))?;
+    builder = builder
+        .merge(create_log_override_config(log_path.to_str())?)
+        .context(ErrorKind::ConfigImmutable)?;
 
-    if let Some(log_path) = parsed_args.log {
-        config
-            .set("Log.file", log_path.to_str())
-            .context(ErrorKind::ConfigImmutable)?;
+    match builder.build() {
+        Ok(config) => {
+            let db_url = db_conn_string(&config)?;
+            // Pass db_url directly to the function that needs it
+            some_function_needs_db_url(db_url)?;
+            Ok(config)
+        },
+        Err(e) => Err(e.into()),
     }
+}
 
-    Ok(config)
+fn create_override_config(config_file: &str) -> Result<Config> {
+    let mut overrides = Config::default();
+    overrides.set("cfg_file", config_file)?;
+    Ok(overrides)
 }
 
 pub fn db_conn_string(config: &Config) -> Result<String> {
@@ -87,44 +84,25 @@ pub fn db_conn_string(config: &Config) -> Result<String> {
         .collect::<Result<_, _>>()
         .context(ErrorKind::ConfigMissingKeys)?;
 
-    match string_vec[0].as_str()
-        {
-            "postgres" | "postgresql" => (),
-            _ => Err(ErrorKind::UnsupportedDbScheme)?,
-        }
+    let supported_schemes = ["postgres", "postgresql", "mysql", "sqlite"];
+    if !supported_schemes.contains(&string_vec[0].as_str()) {
+        Err(ErrorKind::UnsupportedDbScheme)?;
+    }
 
-    Ok(format!(
-        "{scheme}://{username}:{password}@{host}:{port}/{database}",
-        scheme = string_vec[0],
-        username = string_vec[1],
-        password = string_vec[2],
-        host = string_vec[3],
-        port = string_vec[4],
-        database = string_vec[5],
-    ))
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("Configuration was missing expected keys: [{:?}]", _0)]
-pub struct MissingKeys(Vec<String>);
-
-#[derive(Clone, Copy, Debug, Eq, thiserror::Error, Hash, PartialEq)]
-pub enum ErrorKind {
-    #[error("Unsupported database scheme, only 'postgres' and 'postgresql' are allowed.")]
-    UnsupportedDbScheme,
-    #[error("Configuration was missing expected keys")]
-    ConfigMissingKeys,
-    #[error("Config struct cannot be modified")]
-    ConfigImmutable,
+    Ok(concat!(
+        string_vec[0], "://", string_vec[1], ":", string_vec[2], "@
+        string_vec[0], "://", string_vec[1], ":", string_vec[2], "@", string_vec[3], ":", string_vec[4], "/", string_vec[5],
+    ).to_string())
 }
 
 #[cfg(feature = "simple-logging")]
-pub fn begin_log(config: &config::Config) {
-    use log::LevelFilter;
-
-    match config.get_string("Log.file").unwrap().as_ref() {
-        "_CONSOLE_" => (),
-        l => simple_logging::log_to_file(l, LevelFilter::Debug).unwrap(),
+pub fn begin_log(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    match config.get_string("Log.file")?.as_ref() {
+        "_CONSOLE_" => Ok(()),
+        l => {
+            simple_logging::log_to_file(l, level)?;
+            Ok(())
+        },
     }
 }
 

--- a/src/new-broken-lib.rs
+++ b/src/new-broken-lib.rs
@@ -1,0 +1,135 @@
+//-
+// THIS IS THE BROKEN VERSION OF ./src/lib.rs
+// It was created to use the config::Builder, and does not compile.
+//
+use std::io::ErrorKind;
+use anyhow::{Context, Result};
+use clap::Parser;
+use clap_verbosity_flag::Verbosity;
+use config::{Config, Environment, File, FileFormat};
+use log::LevelFilter;
+use std::path::PathBuf;
+use url::Url;
+use thiserror::Error;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    #[arg(short = 'c', long, help = "Sets a custom config file")]
+    config: Option<PathBuf>,
+
+    #[arg(short = 'l', long, help = "Sets logging destination")]
+    log: Option<PathBuf>,
+
+    #[command(flatten)]
+    verbose: Verbosity,
+}
+
+#[derive(Debug, Error)]
+enum ConfigError {
+    #[error("No config path provided")]
+    NoConfigPath,
+    #[error("No log path provided")]
+    NoLogPath,
+    #[error("Invalid log path provided")]
+    InvalidLogPath,
+    #[error("Failed to get database connection string")]
+    DbConnStringError,
+    #[error("Failed to build configuration")]
+    ConfigBuildError,
+}
+
+pub fn configure(parsed_args: Args) -> Result<(Config, String), ConfigError> {
+    let config_path = parsed_args.config.ok_or(ConfigError::NoConfigPath)?;
+    let log_path = parsed_args.log.ok_or(ConfigError::NoLogPath)?;
+
+    let config = Config::builder()
+        .add_source(File::with_name("default_config.toml", FileFormat::Toml))
+        .set_default(Environment::with_prefix("AARDWOLF").separator("__").ignore_empty(true))
+        .add_source(File::from(&config_path))
+        .with(|builder| {
+            let config_file = config_path.to_str().ok_or(ConfigError::NoConfigPath)?;
+            builder.add_source(File::new(&config_file, FileFormat::Toml)).map_err(|_| ConfigError::ConfigBuildError)?;
+            builder.merge(create_override_config(&config_file)).map_err(|_| ConfigError::ConfigBuildError)?;
+            let env_prefix = env!("CARGO_PKG_NAME").to_ascii_uppercase().replace('-', '_');
+            let env_vars = Environment::with_prefix(env_prefix).separator("_").ignore_empty(true);
+            builder.add_source(env_vars);
+            let log_file = log_path.to_str().ok_or(ConfigError::InvalidLogPath)?;
+            builder.set_override("Log.file", &log_file).map_err(|_| ConfigError::ConfigBuildError)?;
+            Ok(())
+        })?
+        .build().map_err(|_| ConfigError::ConfigBuildError)?;
+
+    let db_url = db_conn_string(&config)?;
+    Ok((config, db_url))
+}
+
+fn db_conn_string(config: &Config) -> Result<String> {
+    let db_type = config.get_string("Database.type")?;
+    let username = config.get_string("Database.username")?;
+    let password = config.get_string("Database.password")?;
+    let host = config.get_string("Database.host")?;
+    let port = config.get_string("Database.port")?;
+    let database = config.get_string("Database.database")?;
+
+    let db_url = Url::parse(&format!("{}://{}:{}@{}:{}/{}", db_type, username, password, host, port, database))?;
+    Ok(db_url.as_str().to_owned())
+}
+
+fn create_override_config(config_file: &str) -> Result<(), ConfigError> {
+    let mut overrides = Config::default();
+    overrides.set("cfg_file", config_file)?;
+    Ok(())
+}
+
+pub fn begin_log(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    let log_file = config.get_string("Log.file")?;
+    if log_file != "_CONSOLE_" {
+        simple_logging::log_to_file(&log_file, level)?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "simple-logging")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}
+
+#[cfg(feature = "syslog")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}
+
+#[cfg(feature = "systemd")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}   let host = config.get_string("Database.host")?;
+    let port = config.get_string("Database.port")?;
+    let database = config.get_string("Database.database")?;
+
+    let db_url = Url::parse(&format!("{}://{}:{}@{}:{}/{}", db_type, username, password, host, port, database))?;
+    Ok(db_url.as_str().to_owned())
+}
+
+pub fn begin_log(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    let log_file = config.get_string("Log.file")?;
+    if log_file != "_CONSOLE_" {
+        simple_logging::log_to_file(&log_file, level)?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "simple-logging")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}
+
+#[cfg(feature = "syslog")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}
+
+#[cfg(feature = "systemd")]
+pub fn begin_log_wrapper(config: &config::Config, level: LevelFilter) -> Result<(), Box<dyn std::error::Error>> {
+    begin_log(config, level)
+}


### PR DESCRIPTION
This PR splits the /src/lib.rs into two versions.  The original; which uses deprecated code (replace with config::Builder), and the most recent shot at creating the config::Builder variant (which is broken: `config run --bin setup`)